### PR TITLE
Fix 24.1-5

### DIFF
--- a/docs/Chap24/24.1.md
+++ b/docs/Chap24/24.1.md
@@ -88,7 +88,7 @@ FOLLOW-AND-MARK-PRED(v)
 ```cpp
 RELAX(u, v, w)
     if v.d > min(w(u, v), w(u, v) + u.d)
-        v.d > min(w(u, v), w(u, v) + u.d)
+        v.d = min(w(u, v), w(u, v) + u.d)
         v.π = u.π
 ```
 


### PR DESCRIPTION
Fixed an erroneous less-than sign to the assignment operator.
From:
```
RELAX(u, v, w)
    if v.d > min(w(u, v), w(u, v) + u.d)
        v.d > min(w(u, v), w(u, v) + u.d)
        v.π = u.π
```
To:
```
RELAX(u, v, w)
    if v.d > min(w(u, v), w(u, v) + u.d)
        v.d = min(w(u, v), w(u, v) + u.d)
        v.π = u.π
```